### PR TITLE
return correct output for multiple or no modes

### DIFF
--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -198,11 +198,11 @@ class Bnchmrkr
       end
 
       max_frequency = frequency_hash.values.max
-      mode_candidate = frequency_hash.select{ |_operand, frequency| frequency == max_frequency }.keys
+      mode_candidate = frequency_hash.select{ |_operand, frequency| frequency.equal?(max_frequency) }.keys
       if max_frequency.equal?(1)
         mode = nil
       else
-        mode = mode_candidate.size > 1 ? mode_candidate : mode_candidate[0]
+        mode = mode_candidate.size > 1 ? mode_candidate : mode_candidate.first
       end
 
       measures.collect {|m| total += m.real }

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -189,19 +189,20 @@ class Bnchmrkr
     @results.each_pair do |name, measures|
       hash[name]     = Hash.new
       frequency_hash = Hash.new(0)
-      mode_candidate = { :frequency => 1, :operand => nil }
       total = 0
 
       sorted = measures.sort { |a,b| a.real <=> b.real }
       measures.each do |measure|
         operand = mode_precision.equal?(0) ? measure.real : measure.real.round(mode_precision)
         frequency_hash[operand] += 1
+      end
 
-        # i hate maths
-        if frequency_hash[operand] > mode_candidate[:frequency] and frequency_hash[operand] > 1
-          mode_candidate[:frequency] = frequency_hash[operand]
-          mode_candidate[:operand]   = operand
-        end
+      max_frequency = frequency_hash.values.max
+      mode_candidate = frequency_hash.select{ |_operand, frequency| frequency == max_frequency }.keys
+      if max_frequency.equal?(1)
+        mode = nil
+      else
+        mode = mode_candidate.size > 1 ? mode_candidate : mode_candidate[0]
       end
 
       measures.collect {|m| total += m.real }
@@ -209,8 +210,7 @@ class Bnchmrkr
       hash[name][:slowest] = sorted.last.real
       hash[name][:mean]    = sprintf('%5f', total / sorted.size).to_f
       hash[name][:median]  = sorted[(sorted.size / 2)].real
-      # TODO need to handle the rare case that we have multiple modes -- https://github.com/chorankates/bnchmrkr/issues/4
-      hash[name][:mode]    = mode_candidate[:operand] # collect key name with highest value
+      hash[name][:mode]    = mode
       hash[name][:total]   = sprintf('%5f', total).to_f
     end
 


### PR DESCRIPTION
returns nil for no modes (no element repeated), single element for unique mode, and array of elements for multiple modes

```
$ rake test
/Users/maureen/.rvm/rubies/ruby-2.0.0-p481/bin/ruby -I"lib:lib" -I"/Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib" "/Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/unit/test_contrived.rb" "test/unit/test_exceptions.rb" "test/unit/test_initialize.rb" 
Loaded suite /Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib/rake/rake_test_loader
Started
...........

Finished in 0.581384 seconds.
-------------------------------------------------------------------------------------------------------------------------------------
11 tests, 33 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------
18.92 tests/s, 56.76 assertions/s
/Users/maureen/.rvm/rubies/ruby-2.0.0-p481/bin/ruby -I"lib:lib" -I"/Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib" "/Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib/rake/rake_test_loader.rb" "test/examples/test_examples.rb" 
Loaded suite /Users/maureen/.rvm/gems/ruby-2.0.0-p481/gems/rake-10.5.0/lib/rake/rake_test_loader
Started
.

Finished in 38.496675 seconds.
-------------------------------------------------------------------------------------------------------------------------------------
1 tests, 10 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-------------------------------------------------------------------------------------------------------------------------------------
0.03 tests/s, 0.26 assertions/s
```
