### PR TITLE
Meta

### DIFF
--- a/.reek
+++ b/.reek
@@ -10,11 +10,26 @@ BooleanParameter:
 ControlParameter:
   enabled: false
 
+DataClump:
+  min_clump_size: 4
+
 DuplicateMethodCall:
   enabled: false
 
+# this is not a real thing
+FeatureEnvy:
+  enabled: false
+
+# this should have understanding of non-required parameters
+LongParameterList:
+  max_params: 5
+
 NestedIterators:
   max_allowed_nesting: 3
+
+# you don't know my life
+NilCheck:
+  enabled: false
 
 # more lacking context judgement - when _would_ you be ok with '!' ?
 PrimaDonnaMethod:
@@ -22,7 +37,15 @@ PrimaDonnaMethod:
 
 # this feels a bit arbitrary.. maybe would make more sense if was an average
 TooManyStatements:
-  max_statements: 15
+  max_statements: 30
+
+# see above
+TooManyInstanceVariables:
+  max_instance_variables: 20
+
+# see above
+TooManyMethods:
+  max_methods: 20
 
 # i don't name my exceptions specifically. that doesn't make me a bad person.
 UncommunicativeVariableName:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ notifications:
   email: false
 
 bundler_args: --without test --jobs 3 --retry 3
-script: bundle exec rake test reek build
+script: bundle exec rake test reek build install

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,8 @@ ruby '2.0.0'
 
 source 'https://rubygems.org'
 
-gem 'rake', '~> 10.5.0', '>= 10.5.0'
-
 group :development do
+  gem 'rake', '~> 10.5.0', '>= 10.5.0'
   gem 'jeweler', '~> 2.0.1', '>= 2.0.1'
   gem 'reek', '~> 3.11', '>= 3.11'
   gem 'test-unit', '~> 3.0.0', '>= 3.0.0'

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # bnchmrkr
 
-i hate the name too, [but..](https://github.com/chorankates/bnchmrkr/issues/1)
+[![build status](https://travis-ci.org/chorankates/bnchmrkr.svg)](https://travis-ci.org/chorankates/bnchmrkr) [![Gem Version](https://badge.fury.io/rb/bnchmrkr.png)](https://rubygems.org/gems/bnchmrkr)
 
 Bnchmrkr (Benchmarker) is a tool to help benchmark different method implementations
 
 it is driven by [Benchmark](http://ruby-doc.org/stdlib-2.0.0/libdoc/benchmark/rdoc/Benchmark.html)
 
+i hate the name too, [but..](https://github.com/chorankates/bnchmrkr/issues/1)
+
 ## usage
 
 ### pre-built gem installation (stable)
-
-[![Gem Version](https://badge.fury.io/rb/bnchmrkr.png)](https://rubygems.org/gems/bnchmrkr)
 
 ```sh
 gem install bnchmrkr
@@ -21,8 +21,6 @@ irb(main):001:0> require 'bnchmrkr'
 ```
 
 ### from-source installation (latest)
-
-[![build status](https://travis-ci.org/chorankates/bnchmrkr.svg)](https://travis-ci.org/chorankates/bnchmrkr)
 
 ```sh
 git clone https://github.com/chorankates/bnchmrkr.git
@@ -76,16 +74,40 @@ overall:
           slowest => stat [0.076243]
 ```
 
-## instance methods
+## methods
+
+### `Bnchmrkr`
+```rb
+attr_reader :executions, :marks, :fastest, :slowest
+...
+def initialize(lambdas, executions = 100)
+def types
+def benchmark!
+def inspect
+def to_s
+def fastest_by_type(type, mode = :real)
+def slowest_by_type(type, mode = :real)
+def fastest_overall
+def slowest_overall
+def is_faster?(a, b, mode = :real)
+def is_slower?(a, b, mode = :real)
+def faster_by_result(a, b, percent = true, mode = :real)
+def faster_by_type(a, b, percent = true, mode = :real)
+def slower_by_type(a, b, percent = true)
+def slower_by_result(a, b, percent = true)
+def calculate_overall(mode = :real)
 ```
-  benchmark!
-  count
-  faster_by
-  fastest_by_type
-  fastest_overall
-  is_faster?
-  is_slower?
-  results
-  slowest_by_type
-  slowest_overall
+
+### `Bnchmrkr::Mark`
+```rb
+attr_reader :computed, :lambda, :name, :mode_precision
+attr_reader :fastest, :slowest, :mean, :median, :mode, :total
+...
+def initialize(name, lambda, mode_precision = 0)
+def add_measure(measure)
+def each(&block)
+def compute
+def inspect
+def reset_computations
+```
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build status](https://travis-ci.org/chorankates/bnchmrkr.svg)](https://travis-ci.org/chorankates/bnchmrkr) [![Gem Version](https://badge.fury.io/rb/bnchmrkr.png)](https://rubygems.org/gems/bnchmrkr)
 
-Bnchmrkr (Benchmarker) is a tool to help benchmark different method implementations
+Bnchmrkr (Benchmarker) is a tool to help benchmark different method implementations in Ruby
 
 it is driven by [Benchmark](http://ruby-doc.org/stdlib-2.0.0/libdoc/benchmark/rdoc/Benchmark.html)
 
@@ -14,6 +14,7 @@ i hate the name too, [but..](https://github.com/chorankates/bnchmrkr/issues/1)
 - [examples](#examples)
   - [code](#code)
   - [output](#output)
+  - [converting from < 0.1.1](#upgrading)
 - [methods](#methods)
   - [Bnchmrkr](#bnchmrkr)
   - [Bnchmrkr::Mark](#bnchmrkrmark)
@@ -45,7 +46,7 @@ irb(main):001:0> require 'bnchmrkr'
 
 ## examples
 
-### code 
+### code
 
 ```rb
 tester = Bnchmrkr.new({
@@ -86,6 +87,26 @@ stat:
 overall:
           fastest => ls [0.005704]
           slowest => stat [0.076243]
+```
+
+### upgrading
+
+`Bnchmrkr` follows semantic versioning, which allowed a breaking change from versions `0.1.1` to `0.2.0`
+
+`0.2.0` significantly improves the API and implementation for `Bnchmrkr`, and while upgrading will require some client side changes, they shouldn't be too onerous:
+
+for the most part, you should be able to update the Hash lookup key with a method call of the same name,
+
+#### < 0.1.1
+```rb
+assert_equal(:iterative, tester.fastest_overall[:name])
+assert_equal(:recursive, tester.slowest_overall[:name])
+```
+
+#### >= 0.2.0
+```rb
+assert_equal(:iterative, tester.fastest_overall.name)
+assert_equal(:recursive, tester.slowest_overall.name)
 ```
 
 ## methods

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ it is driven by [Benchmark](http://ruby-doc.org/stdlib-2.0.0/libdoc/benchmark/rd
 
 i hate the name too, [but..](https://github.com/chorankates/bnchmrkr/issues/1)
 
+- [usage](#usage)
+  - [pre-built gem installation (stable)](#pre-built-gem-installation-stable)
+  - [from-source installation (latest)](#from-source-installation-latest)
+- [examples](#examples)
+  - [code](#code)
+  - [output](#output)
+- [methods](#methods)
+  - [Bnchmrkr](#bnchmrkr)
+  - [Bnchmrkr::Mark](#bnchmrkrmark)
+
 ## usage
 
 ### pre-built gem installation (stable)
@@ -35,6 +45,8 @@ irb(main):001:0> require 'bnchmrkr'
 
 ## examples
 
+### code 
+
 ```rb
 tester = Bnchmrkr.new({
   :count_to_1k   => lambda { 1.upto(1000).each   { |i| i } },
@@ -48,6 +60,8 @@ tester.benchmark!
 
 puts tester
 ```
+
+### output
 
 ```
 $ ruby examples/ls_vs_stat.rb

--- a/Rakefile
+++ b/Rakefile
@@ -66,3 +66,8 @@ Reek::Rake::Task.new do |t|
   t.fail_on_error = false
   t.verbose       = true
 end
+
+desc 'install the gem'
+task :install do
+  sh 'gem install log4r-sequel'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ end
 
 Reek::Rake::Task.new do |t|
   t.config_file   = File.join(BASEDIR, '.reek')
-  t.source_files  = './**/*.rb'
+  t.source_files  = FileList.new('lib/**/*.rb', 'test/**/*.rb')
   t.reek_opts     = '--no-wiki-links'
   t.fail_on_error = false
   t.verbose       = true

--- a/examples/fibonacci.rb
+++ b/examples/fibonacci.rb
@@ -56,8 +56,8 @@ class TestFibonacci < Test::Unit::TestCase
 
     assert_true(tester.is_faster?(:iterative, :recursive))
     assert_true(tester.is_slower?(:recursive, :iterative))
-    assert_equal(:iterative, tester.fastest_overall[:name])
-    assert_equal(:recursive, tester.slowest_overall[:name])
+    assert_equal(:iterative, tester.fastest_overall.name)
+    assert_equal(:recursive, tester.slowest_overall.name)
 
   end
 

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -34,7 +34,7 @@ class Bnchmrkr
     @marks.keys
   end
 
-  # 10 lines to actually do the work..
+  # < 10 lines to actually do the work..
   def benchmark!
     @marks.each_pair do |_name, mark|
       1.upto(@executions).each do |_execution|

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -172,14 +172,13 @@ class Bnchmrkr
   def calculate_overall(mode = :real)
 
     @marks.each_pair do |_name, mark|
-      if @fastest.nil? or mark.fastest.__send__(mode) < @fastest.__send__(mode)
+      if @fastest.nil? or mark.fastest.__send__(mode) < @fastest.fastest.__send__(mode)
         @fastest = mark
       end
 
-      if @slowest.nil? or mark.slowest.__send__(mode) > @slowest.__send__(mode)
+      if @slowest.nil? or mark.slowest.__send__(mode) > @slowest.slowest.__send__(mode)
         @slowest = mark
       end
-
 
     end
 

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -85,17 +85,19 @@ class Bnchmrkr
   end
 
   # +type+ name of a lambda that is known
-  # find and return the fastest Bnchrmrkr::Mark per lambda of +type+
-  def fastest_by_type(type)
+  # +mode+ method to use on the Bnchmrkr::Mark object ot compare (:real, :cstime, :cutime, :stime, :utime, :total)
+  # find and return the fastest Bnchrmrkr::Mark runtime per lambda of +type+
+  def fastest_by_type(type, mode = :real)
     return nil unless @marks.has_key?(type)
-    @marks[type].fastest
+    @marks[type].fastest.__send__(mode)
   end
 
   # +type+ name of a lambda that is known
-  # find and return the slowest Bnchrmrkr::Mark per lambda of +type+
-  def slowest_by_type(type)
+  # +mode+ method to use on the Bnchmrkr::Mark object ot compare (:real, :cstime, :cutime, :stime, :utime, :total)
+  # find and return the slowest Bnchrmrkr::Mark runtime per lambda of +type+
+  def slowest_by_type(type, mode = :real)
     return nil unless @marks.has_key?(type)
-    @marks[type].slowest
+    @marks[type].slowest.__send__(mode)
   end
 
   # find and return the fastest overall execution (regardless of lambda type)
@@ -124,7 +126,7 @@ class Bnchmrkr
   # +b+ Bnchmrlr::Mark
   # +mode+ :fastest, :slowest, :mean, :median, :total
   # return boolean if a is faster than b, false if invalid
-  def is_slower?(a, b, mode = :total)
+  def is_slower?(a, b, mode = :real)
     ! is_faster?(a, b, mode)
   end
 

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -172,11 +172,11 @@ class Bnchmrkr
   def calculate_overall(mode = :real)
 
     @marks.each_pair do |_name, mark|
-      if @fastest.nil? or mark.fastest.__send__(mode) < @fastest.fastest.__send__(mode)
+      if @fastest.eql?(:uncomputed) or mark.fastest.__send__(mode) < @fastest.fastest.__send__(mode)
         @fastest = mark
       end
 
-      if @slowest.nil? or mark.slowest.__send__(mode) > @slowest.slowest.__send__(mode)
+      if @slowest.eql?(:uncomputed) or mark.slowest.__send__(mode) > @slowest.slowest.__send__(mode)
         @slowest = mark
       end
 

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -1,88 +1,11 @@
 #!/usr/bin/ruby
+# Bnchmrkr is a tool to help Benchmark.measure {} and compare different method implementations
+
+$LOAD_PATH << sprintf('%s/../lib', File.dirname(__FILE__))
+require 'bnchmrkr/mark'
 
 require 'benchmark'
 
-class Bnchmrkr; end # empty class to keep Ruby and my ordering preferences happy
-
-# Bnchmrkr::Mark represents individual lambda runs within a Bnchmrkr run
-class Bnchmrkr::Mark
-  include Enumerable
-
-  attr_reader :computed, :lambda, :name, :mode_precision
-  attr_reader :fastest, :slowest, :mean, :median, :mode, :total
-
-  def initialize(name, lambda, mode_precision = 0)
-    @name      = name
-    @lambda    = lambda # TODO this name is going to cause problems
-    @measures  = Array.new
-    @computed  = false
-
-    @mode_precision = mode_precision
-  end
-
-  # +measure+ Benchmark.measure{} result
-  def add_measure(measure)
-    @measures << measure
-  end
-
-  # allows Array-like behavior on the Array of measurements contained in a Bnchmrkr::Mark
-  def each(&block)
-    @measures.each(&block)
-  end
-
-  # generate (and TODO cache) results of computations
-  def compute
-    frequency_hash = Hash.new(0)
-    total          = 0
-
-    sorted = @measures.sort { |a,b| a.real <=> b.real }
-
-    @measures.each do |measure|
-      operand = @mode_precision.equal?(0) ? measure.real : measure.real.round(@mode_precision)
-      frequency_hash[operand] += 1
-    end
-
-    max_frequency  = frequency_hash.values.max
-    mode_candidate = frequency_hash.select{ |_operand, frequency| frequency.equal?(max_frequency) }.keys
-
-    if max_frequency.equal?(1)
-      mode = nil
-    else
-      mode = mode_candidate.size > 1 ? mode_candidate : mode_candidate.first
-    end
-
-    sorted.collect { |r| total += r.real }
-    @fastest = sorted.first
-    @slowest = sorted.last
-    @mean    = sprintf('%5f', total / sorted.size).to_f
-    @median  = sorted[(sorted.size / 2)]
-    @mode    = mode
-    @total   = sprintf('%5f', total).to_f
-
-    @computed = true
-  end
-
-  # a semi-fancy and somewhat fragile inspect method
-  ## try to compute if we haven't been, ensuring we always return a hash
-  def inspect
-    begin
-      self.compute unless @computed
-      {
-        :fastest => @fastest.real,
-        :slowest => @slowest.real,
-        :mean    => @mean,
-        :median  => @median,
-        :mode    => @mode,
-        :total   => @total,
-      }
-    rescue => e
-      { }
-    end
-  end
-
-end
-
-# Bnchmrkr is a tool to help Benchmark.measure {} and compare different method implementations
 class Bnchmrkr
 
   attr_reader :executions, :marks, :fastest, :slowest
@@ -191,7 +114,7 @@ class Bnchmrkr
   # +b+ Symbol that represents a known lambda
   # +mode+ :fastest, :slowest, :mean, :median, :total
   # return boolean if a is faster than b, false if invalid
-  def is_faster?(a, b, mode = :total)
+  def is_faster?(a, b, mode = :real)
     return false unless @marks.has_key?(a) and @marks.has_key?(b)
     # TODO not sure that we're doing the right thing here.. the fastest fast run should always be faster than the slowest slow run.. but should we be comparing fastest fast with slowest fast?
     @marks[a].fastest.__send__(mode) < @marks[b].fastest.__send__(mode)

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -14,8 +14,9 @@ class Bnchmrkr
     @executions  = executions
     @marks       = Hash.new
 
-    @fastest = nil
-    @slowest = nil
+    # TODO need to cache these computations and allow reseting similar to how Bnchmrkr::Mark works
+    @fastest = :uncomputed
+    @slowest = :uncomputed
 
     lambdas.each_pair do |name, l|
       unless name.class.eql?(Symbol) and l.class.eql?(Proc)

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/ruby
-# Bnchmrkr is a tool to help Benchmark.measure {} and compare different method implementations
 
 $LOAD_PATH << sprintf('%s/../lib', File.dirname(__FILE__))
 require 'bnchmrkr/mark'
 
 require 'benchmark'
 
+# Bnchmrkr is a tool to help Benchmark.measure {} and compare different method implementations
 class Bnchmrkr
 
   attr_reader :executions, :marks, :fastest, :slowest
@@ -172,23 +172,24 @@ class Bnchmrkr
   def calculate_overall(mode = :real)
 
     @marks.each_pair do |_name, mark|
-      if @fastest.nil? or mark.fastest.__send__(mode) < @fastest.fastest.__send__(mode)
+      if @fastest.nil? or mark.fastest.__send__(mode) < @fastest.__send__(mode)
         @fastest = mark
       end
 
-      if @slowest.nil? or mark.slowest.__send__(mode) > @slowest.slowest.__send__(mode)
+      if @slowest.nil? or mark.slowest.__send__(mode) > @slowest.__send__(mode)
         @slowest = mark
       end
 
 
     end
 
-    p = {
-      :fastest => @fastest,
-      :slowest => @slowest,
-      :faster_by => self.faster_by_result(@fastest.fastest, @slowest.slowest)
+    {
+      :fastest      => @fastest.fastest.__send__(mode),
+      :fastest_name => @fastest.name,
+      :slowest      => @slowest.slowest.__send__(mode),
+      :slowest_name => @slowest.name,
+      :faster_by    => self.faster_by_result(@fastest.fastest, @slowest.slowest)
     }
-    return p
   end
 
 end

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -49,7 +49,6 @@ class Bnchmrkr
   end
 
   def inspect
-    return {:foo => { :bar => 'baz'}} if @fastest.nil?
     {
       :fastest => {
         :name    => @fastest.name,

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -123,7 +123,7 @@ class Bnchmrkr
   end
 
   # +a+ Bnchmrkr::Mark
-  # +b+ Bnchmrlr::Mark
+  # +b+ Bnchmrkr::Mark
   # +mode+ :fastest, :slowest, :mean, :median, :total
   # return boolean if a is faster than b, false if invalid
   def is_slower?(a, b, mode = :real)

--- a/lib/bnchmrkr.rb
+++ b/lib/bnchmrkr.rb
@@ -8,6 +8,8 @@ require 'benchmark'
 # Bnchmrkr is a tool to help Benchmark.measure {} and compare different method implementations
 class Bnchmrkr
 
+  UNCOMPUTED = :uncomputed
+
   attr_reader :executions, :marks, :fastest, :slowest
 
   def initialize(lambdas, executions = 100)
@@ -15,8 +17,8 @@ class Bnchmrkr
     @marks       = Hash.new
 
     # TODO need to cache these computations and allow reseting similar to how Bnchmrkr::Mark works
-    @fastest = :uncomputed
-    @slowest = :uncomputed
+    @fastest = UNCOMPUTED
+    @slowest = UNCOMPUTED
 
     lambdas.each_pair do |name, l|
       unless name.class.eql?(Symbol) and l.class.eql?(Proc)
@@ -88,7 +90,7 @@ class Bnchmrkr
   # +mode+ method to use on the Bnchmrkr::Mark object ot compare (:real, :cstime, :cutime, :stime, :utime, :total)
   # find and return the fastest Bnchrmrkr::Mark runtime per lambda of +type+
   def fastest_by_type(type, mode = :real)
-    return nil unless @marks.has_key?(type)
+    return UNCOMPUTED unless @marks.has_key?(type)
     @marks[type].fastest.__send__(mode)
   end
 
@@ -96,7 +98,7 @@ class Bnchmrkr
   # +mode+ method to use on the Bnchmrkr::Mark object ot compare (:real, :cstime, :cutime, :stime, :utime, :total)
   # find and return the slowest Bnchrmrkr::Mark runtime per lambda of +type+
   def slowest_by_type(type, mode = :real)
-    return nil unless @marks.has_key?(type)
+    return UNCOMPUTED unless @marks.has_key?(type)
     @marks[type].slowest.__send__(mode)
   end
 

--- a/lib/bnchmrkr/mark.rb
+++ b/lib/bnchmrkr/mark.rb
@@ -1,0 +1,80 @@
+# oh ruby
+class Bnchmrkr; end
+
+# Bnchmrkr::Mark represents individual lambda runs within a Bnchmrkr run
+class Bnchmrkr::Mark
+  include Enumerable
+
+  attr_reader :computed, :lambda, :name, :mode_precision
+  attr_reader :fastest, :slowest, :mean, :median, :mode, :total
+
+  def initialize(name, lambda, mode_precision = 0)
+    @name      = name
+    @lambda    = lambda # TODO this name is going to cause problems
+    @measures  = Array.new
+    @computed  = false
+
+    @mode_precision = mode_precision
+  end
+
+  # +measure+ Benchmark.measure{} result
+  def add_measure(measure)
+    @measures << measure
+  end
+
+  # allows Array-like behavior on the Array of measurements contained in a Bnchmrkr::Mark
+  def each(&block)
+    @measures.each(&block)
+  end
+
+  # generate (and TODO cache) results of computations
+  def compute
+    frequency_hash = Hash.new(0)
+    total          = 0
+
+    sorted = @measures.sort { |a,b| a.real <=> b.real }
+
+    @measures.each do |measure|
+      operand = @mode_precision.equal?(0) ? measure.real : measure.real.round(@mode_precision)
+      frequency_hash[operand] += 1
+    end
+
+    max_frequency  = frequency_hash.values.max
+    mode_candidate = frequency_hash.select{ |_operand, frequency| frequency.equal?(max_frequency) }.keys
+
+    if max_frequency.equal?(1)
+      mode = nil
+    else
+      mode = mode_candidate.size > 1 ? mode_candidate : mode_candidate.first
+    end
+
+    sorted.collect { |r| total += r.real }
+    @fastest = sorted.first
+    @slowest = sorted.last
+    @mean    = sprintf('%5f', total / sorted.size).to_f
+    @median  = sorted[(sorted.size / 2)]
+    @mode    = mode
+    @total   = sprintf('%5f', total).to_f
+
+    @computed = true
+  end
+
+  # a semi-fancy and somewhat fragile inspect method
+  ## try to compute if we haven't been, ensuring we always return a hash
+  def inspect
+    begin
+      self.compute unless @computed
+      {
+          :fastest => @fastest.real,
+          :slowest => @slowest.real,
+          :mean    => @mean,
+          :median  => @median,
+          :mode    => @mode,
+          :total   => @total,
+      }
+    rescue => e
+      { }
+    end
+  end
+
+end

--- a/lib/bnchmrkr/mark.rb
+++ b/lib/bnchmrkr/mark.rb
@@ -12,14 +12,16 @@ class Bnchmrkr::Mark
     @name      = name
     @lambda    = lambda # TODO this name is going to cause problems
     @measures  = Array.new
-    @computed  = false
 
     @mode_precision = mode_precision
+
+    reset_computations # initialize to known values
   end
 
   # +measure+ Benchmark.measure{} result
   def add_measure(measure)
     @measures << measure
+    reset_computations if @computed # as soon as a measure is added, previous computations are invalid
   end
 
   # allows Array-like behavior on the Array of measurements contained in a Bnchmrkr::Mark
@@ -27,7 +29,6 @@ class Bnchmrkr::Mark
     @measures.each(&block)
   end
 
-  # generate (and TODO cache) results of computations
   def compute
     frequency_hash = Hash.new(0)
     total          = 0
@@ -65,6 +66,7 @@ class Bnchmrkr::Mark
     begin
       self.compute unless @computed
       {
+        :name    => @name,
         :fastest => @fastest.real,
         :slowest => @slowest.real,
         :mean    => @mean,
@@ -73,8 +75,21 @@ class Bnchmrkr::Mark
         :total   => @total,
       }
     rescue => e
-      { }
+      { :name => @name, :computed => @computed }
     end
+  end
+
+  private
+
+  # reset internal computed values, used when a new measure is added
+  def reset_computations
+    @computed = false
+    @fastest  = :uncomputed
+    @slowest  = :uncomputed
+    @mean     = :uncomputed
+    @median   = :uncomputed
+    @mode     = :uncomputed
+    @total    = :uncomputed
   end
 
 end

--- a/lib/bnchmrkr/mark.rb
+++ b/lib/bnchmrkr/mark.rb
@@ -65,12 +65,12 @@ class Bnchmrkr::Mark
     begin
       self.compute unless @computed
       {
-          :fastest => @fastest.real,
-          :slowest => @slowest.real,
-          :mean    => @mean,
-          :median  => @median,
-          :mode    => @mode,
-          :total   => @total,
+        :fastest => @fastest.real,
+        :slowest => @slowest.real,
+        :mean    => @mean,
+        :median  => @median,
+        :mode    => @mode,
+        :total   => @total,
       }
     rescue => e
       { }

--- a/test/examples/test_examples.rb
+++ b/test/examples/test_examples.rb
@@ -12,8 +12,10 @@ class TestExamples < Test::Unit::TestCase
     @files.each do |file|
       raw = `ruby #{file}`
 
-      assert_true($?.success?)
-      assert_not_nil(raw)
+      generic_failure_message = sprintf('[%s] returned [%s]: [%s]', File.basename(file), $?, raw)
+
+      assert_true($?.success?, generic_failure_message)
+      assert_not_nil(raw, generic_failure_message)
     end
   end
 

--- a/test/unit/test_contrived.rb
+++ b/test/unit/test_contrived.rb
@@ -25,8 +25,10 @@ class TestContrived < Test::Unit::TestCase
     slowest_overall = @tester.slowest_overall
     fastest_overall = @tester.fastest_overall
 
-    assert_equal(:count_to_100k, slowest_overall.name)
-    assert_true(slowest_overall.slowest.real > fastest_overall.fastest.real)
+    generic_failure_message = sprintf('fast[%s] slow[%s]', fastest_overall, slowest_overall)
+
+    assert_equal(:count_to_100k, slowest_overall.name, generic_failure_message)
+    assert_true(slowest_overall.slowest.real > fastest_overall.fastest.real, generic_failure_message)
   end
 
   def test_speed_by_type
@@ -34,7 +36,9 @@ class TestContrived < Test::Unit::TestCase
       slowest = @tester.slowest_by_type(type).real
       fastest = @tester.fastest_by_type(type).real
 
-      assert_true(slowest > fastest)
+      generic_failure_message = sprintf('fast[%s] slow[%s]', fastest, slowest)
+
+      assert_true(slowest > fastest, generic_failure_message)
     end
   end
 
@@ -42,48 +46,56 @@ class TestContrived < Test::Unit::TestCase
     fast = @tester.fastest_overall.name
     slow = @tester.slowest_overall.name
 
+    generic_failure_message = sprintf('fast[%s] slow[%s]', fast, slow)
+
     forward = @tester.is_faster?(fast, slow)
     reverse = @tester.is_faster?(slow, fast)
     equal   = @tester.is_faster?(fast, fast)
 
-    assert_not_equal(forward, reverse) # TODO this is currently failing.. think it is related to .slowest vs .fastest
-    assert_true(forward)
-    assert_false(reverse)
-    assert_false(equal)
+    assert_not_equal(forward, reverse, generic_failure_message)
+    assert_true(forward, generic_failure_message)
+    assert_false(reverse, generic_failure_message)
+    assert_false(equal, generic_failure_message)
   end
 
   def test_is_slower?
     fast = @tester.fastest_overall.name
     slow = @tester.slowest_overall.name
 
+    generic_failure_message = sprintf('fast[%s] slow[%s]', fast, slow)
+
     forward = @tester.is_slower?(slow, fast)
     reverse = @tester.is_slower?(fast, slow)
     equal   = @tester.is_slower?(slow, slow)
 
-    assert_not_equal(forward, reverse)
-    assert_true(forward)
-    assert_false(reverse)
-    assert_true(equal) # ugh, this is misleading.. but is_slower? is boolean opposite of is_slower?
+    assert_not_equal(forward, reverse, generic_failure_message)
+    assert_true(forward, generic_failure_message)
+    assert_false(reverse, generic_failure_message)
+    assert_true(equal, sprintf('fast[%s] slow[%s]', fast, slow))
   end
 
   def test_faster_by_result
     fast = @tester.fastest_overall.fastest
     slow = @tester.slowest_overall.slowest
 
-    assert_not_nil(@tester.faster_by_result(fast, slow, true))
-    assert_match(/\d+\.\d+%/, @tester.faster_by_result(fast, slow, true))
-    assert_true(@tester.faster_by_result(fast, slow, false).is_a?(Float))
-    assert_false(@tester.faster_by_result(slow, fast))
+    generic_failure_message = sprintf('fast[%s] slow[%s]', fast, slow)
+
+    assert_not_nil(@tester.faster_by_result(fast, slow, true), generic_failure_message)
+    assert_match(/\d+\.\d+%/, @tester.faster_by_result(fast, slow, true), generic_failure_message)
+    assert_true(@tester.faster_by_result(fast, slow, false).is_a?(Float), generic_failure_message)
+    assert_false(@tester.faster_by_result(slow, fast), generic_failure_message)
   end
 
   def test_faster_by_type
     fastest = @tester.fastest_overall.name
     slowest = @tester.slowest_overall.name
 
-    assert_not_nil(@tester.faster_by_type(fastest, slowest, true))
-    assert_match(/\d+\.\d+%/, @tester.faster_by_type(fastest, slowest, true))
-    assert_true(@tester.faster_by_type(fastest, slowest, false).is_a?(Float))
-    assert_false(@tester.faster_by_type(slowest, fastest))
+    generic_failure_message = sprintf('fast[%s] slow[%s]', fastest, slowest)
+
+    assert_not_nil(@tester.faster_by_type(fastest, slowest, true), generic_failure_message)
+    assert_match(/\d+\.\d+%/, @tester.faster_by_type(fastest, slowest, true), generic_failure_message)
+    assert_true(@tester.faster_by_type(fastest, slowest, false).is_a?(Float), generic_failure_message)
+    assert_false(@tester.faster_by_type(slowest, fastest), generic_failure_message)
   end
 
 end

--- a/test/unit/test_contrived.rb
+++ b/test/unit/test_contrived.rb
@@ -17,44 +17,44 @@ class TestContrived < Test::Unit::TestCase
   end
 
   def test_fastest
-    assert_equal(:count_to_1k, @tester.fastest_overall[:name])
-    assert_true(@tester.fastest_overall[:measure] < @tester.slowest_overall[:measure])
+    assert_equal(:count_to_1k, @tester.fastest_overall.name)
+    assert_true(@tester.fastest_overall.fastest.real < @tester.slowest_overall.slowest.real)
   end
 
   def test_slowest
     slowest_overall = @tester.slowest_overall
     fastest_overall = @tester.fastest_overall
 
-    assert_equal(:count_to_100k, slowest_overall[:name])
-    assert_true(slowest_overall[:measure] > fastest_overall[:measure])
+    assert_equal(:count_to_100k, slowest_overall.name)
+    assert_true(slowest_overall.slowest.real > fastest_overall.fastest.real)
   end
 
   def test_speed_by_type
     @tester.types.each do |type|
-      slowest = @tester.slowest_by_type(type)
-      fastest = @tester.fastest_by_type(type)
+      slowest = @tester.slowest_by_type(type).real
+      fastest = @tester.fastest_by_type(type).real
 
       assert_true(slowest > fastest)
     end
   end
 
   def test_is_faster?
-    fast = @tester.fastest_overall[:name]
-    slow = @tester.slowest_overall[:name]
+    fast = @tester.fastest_overall.name
+    slow = @tester.slowest_overall.name
 
     forward = @tester.is_faster?(fast, slow)
     reverse = @tester.is_faster?(slow, fast)
     equal   = @tester.is_faster?(fast, fast)
 
-    assert_not_equal(forward, reverse)
+    assert_not_equal(forward, reverse) # TODO this is currently failing.. think it is related to .slowest vs .fastest
     assert_true(forward)
     assert_false(reverse)
     assert_false(equal)
   end
 
   def test_is_slower?
-    fast = @tester.fastest_overall[:name]
-    slow = @tester.slowest_overall[:name]
+    fast = @tester.fastest_overall.name
+    slow = @tester.slowest_overall.name
 
     forward = @tester.is_slower?(slow, fast)
     reverse = @tester.is_slower?(fast, slow)
@@ -67,8 +67,8 @@ class TestContrived < Test::Unit::TestCase
   end
 
   def test_faster_by_result
-    fast = @tester.fastest_overall
-    slow = @tester.slowest_overall
+    fast = @tester.fastest_overall.fastest
+    slow = @tester.slowest_overall.slowest
 
     assert_not_nil(@tester.faster_by_result(fast, slow, true))
     assert_match(/\d+\.\d+%/, @tester.faster_by_result(fast, slow, true))
@@ -77,14 +77,13 @@ class TestContrived < Test::Unit::TestCase
   end
 
   def test_faster_by_type
-    fastest = @tester.fastest_overall[:name]
-    slowest = @tester.slowest_overall[:name]
+    fastest = @tester.fastest_overall.name
+    slowest = @tester.slowest_overall.name
 
     assert_not_nil(@tester.faster_by_type(fastest, slowest, true))
     assert_match(/\d+\.\d+%/, @tester.faster_by_type(fastest, slowest, true))
     assert_true(@tester.faster_by_type(fastest, slowest, false).is_a?(Float))
     assert_false(@tester.faster_by_type(slowest, fastest))
-
   end
 
 end

--- a/test/unit/test_exceptions.rb
+++ b/test/unit/test_exceptions.rb
@@ -6,17 +6,21 @@ class TestExceptions < Test::Unit::TestCase
 
   def setup; end
 
-  def test_lambdas_will_raise
+  def test_lambdas_will_raise # but we will catch them
+    symbol = :divbyzero
+
     tester = Bnchmrkr.new({
-      :divbyzero => lambda {
+      symbol => lambda {
         10 / 0
       },
     })
 
-    assert_nothing_raised do
+    e = assert_raise do
       tester.benchmark!
-      assert_true(tester.results.has_key?('divbyzero-failed'.to_sym))
     end
+
+    assert_true(tester.marks.has_key?(symbol))
+    assert_equal(ZeroDivisionError, e.class)
   end
 
   def test_lambdas_wont_raise_anyway
@@ -26,7 +30,7 @@ class TestExceptions < Test::Unit::TestCase
 
     assert_nothing_raised do
       tester.benchmark!
-      assert_true(tester.results.has_key?(:foo))
+      assert_true(tester.marks.has_key?(:foo))
     end
 
   end

--- a/test/unit/test_initialize.rb
+++ b/test/unit/test_initialize.rb
@@ -19,6 +19,19 @@ class TestInitialize < Test::Unit::TestCase
 
   end
 
+  # TODO this is really testing Bnchmrkr::Mark objects
+  def test_initial_values
+
+    bnchmrkr = Bnchmrkr.new({:foo => lambda {}})
+
+    bnchmrkr.marks.each_pair do |name, m|
+      [ :fastest, :slowest, :mean, :median, :mode, :total ].each do |a|
+        assert_equal(:uncomputed, m.__send__(a), sprintf('failed[%s] for[%s]', a, name))
+      end
+    end
+
+  end
+
   def test_invalid
 
     # not a proc
@@ -48,8 +61,6 @@ class TestInitialize < Test::Unit::TestCase
     assert_raise ArgumentError do
       Bnchmrkr.new({:foo => :bar}, 1.1)
     end
-
-
 
   end
 


### PR DESCRIPTION
working on #3, modelling measures as objects:
- addition of `@marks`, an Array of `Bnchmrkr::Mark` objects to replace the `@results` Array previously containing records of runs
- `Bnchmrkr::Mark`:

``` rb
attr_reader :computed, :lambda, :name, :mode_precision
attr_reader :fastest, :slowest, :mean, :median, :mode, :total
...
def initialize(name, lambda, mode_precision = 0)
def add_measure(measure)
def each(&block)
def compute
def inspect
def reset_computations
```
- `Bnchmrkr`:

``` rb
attr_reader :executions, :marks, :fastest, :slowest
...
def initialize(lambdas, executions = 100)
def types
def benchmark!
def inspect
def to_s
def fastest_by_type(type, mode = :real)
def slowest_by_type(type, mode = :real)
def fastest_overall
def slowest_overall
def is_faster?(a, b, mode = :real)
def is_slower?(a, b, mode = :real)
def faster_by_result(a, b, percent = true, mode = :real)
def faster_by_type(a, b, percent = true, mode = :real)
def slower_by_type(a, b, percent = true)
def slower_by_result(a, b, percent = true)
def calculate_overall(mode = :real)
```

TODO:
- [x] make a decision about how we should store the measure that will be used to compare against others in`fastest` and `slowest`, previously they were just times, now they are `Benchmark::Measure` objects
- [x] update examples to ensure they don't have use the old API
- [x] bump version
